### PR TITLE
Add support for user defined page controller templates

### DIFF
--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -85,8 +85,11 @@ class main_controller implements main_interface
 			));
 		}
 
+		// Set the page template to use
+		$page_template = ($display) ? $display->get_template() : 'pages_default.html';
+
 		// Send all data to the template file
-		return $this->helper->render('pages_default.html', $page_title);
+		return $this->helper->render($page_template, $page_title);
 	}
 
 	/**

--- a/entity/page.php
+++ b/entity/page.php
@@ -31,6 +31,7 @@ class page implements page_interface
 	*	page_content_allow_html
 	*	page_display
 	*	page_display_to_guests
+	*	page_template
 	* @access protected
 	*/
 	protected $data;
@@ -117,6 +118,7 @@ class page implements page_interface
 			'page_route'					=> 'set_route', // call set_route()
 			'page_display'					=> 'set_page_display', // call set_page_display()
 			'page_display_to_guests'		=> 'set_page_display_to_guests', // call set_page_display_to_guests()
+			'page_template'					=> 'set_template', // call set_template()
 
 			// We do not pass to set_content() as generate_text_for_storage would run twice
 			'page_content'					=> 'string',
@@ -409,6 +411,49 @@ class page implements page_interface
 
 		// Set the route on our data array
 		$this->data['page_order'] = $order;
+
+		return $this;
+	}
+
+	/**
+	* Get page template
+	*
+	* @return string page template
+	* @access public
+	*/
+	public function get_template()
+	{
+		return (!empty($this->data['page_template'])) ? (string) $this->data['page_template'] : 'pages_default.html';
+	}
+
+	/**
+	* Set page template
+	*
+	* @param string $template Page template name
+	* @return page_interface $this object for chaining calls; load()->set()->save()
+	* @access public
+	* @throws \phpbb\pages\exception\unexpected_value
+	*/
+	public function set_template($template)
+	{
+		// Enforce a string
+		$template = (string) $template;
+
+		// Template name should follow pages_*.html naming convention
+		// and contain only letters, numbers, hyphens and underscores
+		if ($template != '' && !preg_match('/^pages_[A-Za-z0-9-_]+\.html$/', $template))
+		{
+			throw new \phpbb\pages\exception\unexpected_value(array('template', 'ILLEGAL_CHARACTERS'));
+		}
+
+		// We limit the template name length to 255 characters
+		if (truncate_string($template, 255) != $template)
+		{
+			throw new \phpbb\pages\exception\unexpected_value(array('template', 'TOO_LONG'));
+		}
+
+		// Set the title on our data array
+		$this->data['page_template'] = $template;
 
 		return $this;
 	}

--- a/entity/page_interface.php
+++ b/entity/page_interface.php
@@ -146,6 +146,24 @@ interface page_interface
 	public function set_order($order);
 
 	/**
+	* Get page template
+	*
+	* @return string page template
+	* @access public
+	*/
+	public function get_template();
+
+	/**
+	* Set page template
+	*
+	* @param string $template Page template name
+	* @return page_interface $this object for chaining calls; load()->set()->save()
+	* @access public
+	* @throws \phpbb\pages\exception\unexpected_value
+	*/
+	public function set_template($template);
+
+	/**
 	* Get content for edit
 	*
 	* @return string

--- a/migrations/v10x/m1_initial_schema.php
+++ b/migrations/v10x/m1_initial_schema.php
@@ -50,6 +50,7 @@ class m1_initial_schema extends \phpbb\db\migration\migration
 						'page_content_allow_html'		=> array('BOOL', 0),
 						'page_display'					=> array('BOOL', 0),
 						'page_display_to_guests'		=> array('BOOL', 0),
+						'page_template'					=> array('VCHAR:255', ''),
 					),
 					'PRIMARY_KEY'	=> 'page_id',
 				),

--- a/styles/prosilver/template/pages_blank.html
+++ b/styles/prosilver/template/pages_blank.html
@@ -1,0 +1,26 @@
+{# Use the space below to include external CSS and JS files
+# Here are some example usages:
+#
+# local files relative to this template file (when stored inside phpBB's style directories):
+# <!-- INCLUDEJS script.js -->
+# <!-- INCLUDECSS ../theme/style.css -->
+#
+# hosted on external sites:
+# <!-- INCLUDEJS http://code.jquery.com/jquery-migrate-1.2.1.min.js -->
+# <!-- INCLUDECSS https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css -->
+#
+# local files stored inside the Pages extension:
+# <!-- INCLUDEJS @phpbb_pages/script.js -->
+# <!-- INCLUDECSS @phpbb_pages/../theme/style.css -->
+#
+#}
+<!-- INCLUDECSS @phpbb_pages/../theme/pages_controller.css -->
+<!-- INCLUDE overall_header.html -->
+
+<div class="content pages-content">
+
+	{PAGE_CONTENT}
+
+</div>
+
+<!-- INCLUDE overall_footer.html -->

--- a/styles/subsilver2/template/pages_blank.html
+++ b/styles/subsilver2/template/pages_blank.html
@@ -1,0 +1,30 @@
+{# Use the space below to include external CSS and JS files
+# Here are some example usages:
+#
+# local files relative to this template file (when stored inside phpBB's style directories):
+# <!-- INCLUDEJS script.js -->
+# <!-- INCLUDECSS ../theme/style.css -->
+#
+# hosted on external sites:
+# <!-- INCLUDEJS http://code.jquery.com/jquery-migrate-1.2.1.min.js -->
+# <!-- INCLUDECSS https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css -->
+#
+# local files stored inside the Pages extension:
+# <!-- INCLUDEJS @phpbb_pages/script.js -->
+# <!-- INCLUDECSS @phpbb_pages/../theme/style.css -->
+#
+#}
+<!-- INCLUDECSS @phpbb_pages/../theme/pages_controller.css -->
+<!-- INCLUDE overall_header.html -->
+
+<div class="gen">
+
+	{PAGE_CONTENT}
+
+</div>
+
+<br clear="all" />
+
+<!-- INCLUDE breadcrumbs.html -->
+
+<!-- INCLUDE overall_footer.html -->

--- a/tests/entity/fixtures/page.xml
+++ b/tests/entity/fixtures/page.xml
@@ -13,6 +13,7 @@
 		<column>page_content_allow_html</column>
 		<column>page_display</column>
 		<column>page_display_to_guests</column>
+		<column>page_template</column>
 		<row>
 			<value>1</value>
 			<value>1</value>
@@ -26,6 +27,7 @@
 			<value>0</value>
 			<value>1</value>
 			<value>1</value>
+			<value>pages_default.html</value>
 		</row>
 		<row>
 			<value>2</value>
@@ -40,6 +42,7 @@
 			<value>0</value>
 			<value>1</value>
 			<value>1</value>
+			<value>pages_default.html</value>
 		</row>
 		<row>
 			<value>3</value>
@@ -54,6 +57,7 @@
 			<value>0</value>
 			<value>1</value>
 			<value>0</value>
+			<value>pages_default.html</value>
 		</row>
 		<row>
 			<value>4</value>
@@ -68,6 +72,7 @@
 			<value>1</value>
 			<value>0</value>
 			<value>0</value>
+			<value>pages_default.html</value>
 		</row>
 	</table>
 </dataset>

--- a/tests/entity/page_entity_base.php
+++ b/tests/entity/page_entity_base.php
@@ -84,6 +84,7 @@ class page_entity_base extends \phpbb_database_test_case
 				'page_content_allow_html'			=> 0,
 				'page_display'						=> 1,
 				'page_display_to_guests'			=> 1,
+				'page_template'						=> 'pages_default.html',
 			),
 			2 => array(
 				'page_id'							=> 2,
@@ -98,6 +99,7 @@ class page_entity_base extends \phpbb_database_test_case
 				'page_content_allow_html'			=> 0,
 				'page_display'						=> 1,
 				'page_display_to_guests'			=> 1,
+				'page_template'						=> 'pages_default.html',
 			),
 			3 => array(
 				'page_id'							=> 3,
@@ -112,6 +114,7 @@ class page_entity_base extends \phpbb_database_test_case
 				'page_content_allow_html'			=> 0,
 				'page_display'						=> 1,
 				'page_display_to_guests'			=> 1,
+				'page_template'						=> 'pages_default.html',
 			),
 			4 => array(
 				'page_id'							=> 4,
@@ -126,6 +129,7 @@ class page_entity_base extends \phpbb_database_test_case
 				'page_content_allow_html'			=> 0,
 				'page_display'						=> 1,
 				'page_display_to_guests'			=> 1,
+				'page_template'						=> 'pages_default.html',
 			),
 			5 => array(
 				'page_id'							=> 5,
@@ -140,6 +144,7 @@ class page_entity_base extends \phpbb_database_test_case
 				'page_content_allow_html'			=> 1,
 				'page_display'						=> 1,
 				'page_display_to_guests'			=> 1,
+				'page_template'						=> 'pages_default.html',
 			),
 		);
 	}

--- a/tests/entity/page_entity_template_test.php
+++ b/tests/entity/page_entity_template_test.php
@@ -1,0 +1,101 @@
+<?php
+/**
+*
+* Pages extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace phpbb\pages\tests\entity;
+
+/**
+* Tests related to templates on page entity
+*/
+class page_entity_template_test extends page_entity_base
+{
+	/**
+	* Test data for the test_template() function
+	*
+	* @return array Array of test data
+	* @access public
+	*/
+	public function template_test_data()
+	{
+		return array(
+			// sent to set_template(), expected from get_template()
+			array('pages_foo.html', 'pages_foo.html'),
+			array('', 'pages_default.html'),
+			array(null, 'pages_default.html'),
+
+			// Maximum length
+			array(
+				'pages_' . str_repeat('a', 244) . '.html',
+				'pages_' . str_repeat('a', 244) . '.html',
+			),
+		);
+	}
+
+	/**
+	* Test setting template
+	*
+	* @dataProvider template_test_data
+	* @access public
+	*/
+	public function test_template($template, $expected)
+	{
+		// Setup the entity class
+		$entity = $this->get_page_entity();
+
+		// Set the template
+		$result = $entity->set_template($template);
+
+		// Assert the returned value is what we expect
+		$this->assertInstanceOf('\phpbb\pages\entity\page', $result);
+
+		// Assert that the template matches what's expected
+		$this->assertSame($expected, $entity->get_template($template));
+	}
+
+	/**
+	* Test data for the test_template_fails() function
+	*
+	* @return array Array of test data
+	* @access public
+	*/
+	public function template_fails_test_data()
+	{
+		return array(
+			// Some invalid template names
+			array('foobar'),
+			array('foobar.html'),
+			array('pages_foobar'),
+			array('pages_foobar.htm'),
+			array('pages_føobar.html'),
+			array('pages_foo?bar.html'),
+			array('pages.foobar.html'),
+
+			// Exceeds character maximum length
+			array(
+				'pages_' . str_repeat('a', 245) . '.html',
+			),
+		);
+	}
+
+	/**
+	* Test setting invalid data on the template which should throw an exception
+	*
+	* @dataProvider template_fails_test_data
+	* @expectedException \phpbb\pages\exception\base
+	* @access public
+	*/
+	public function test_template_fails($template)
+	{
+		// Setup the entity class
+		$entity = $this->get_page_entity();
+
+		// Load the entity
+		$entity->set_template($template);
+	}
+}

--- a/tests/operators/fixtures/page.xml
+++ b/tests/operators/fixtures/page.xml
@@ -13,6 +13,7 @@
 		<column>page_content_allow_html</column>
 		<column>page_display</column>
 		<column>page_display_to_guests</column>
+		<column>page_template</column>
 		<row>
 			<value>1</value>
 			<value>1</value>
@@ -26,6 +27,7 @@
 			<value>0</value>
 			<value>1</value>
 			<value>1</value>
+			<value>pages_default.html</value>
 		</row>
 		<row>
 			<value>2</value>
@@ -40,6 +42,7 @@
 			<value>0</value>
 			<value>1</value>
 			<value>1</value>
+			<value>pages_default.html</value>
 		</row>
 		<row>
 			<value>3</value>
@@ -54,6 +57,7 @@
 			<value>0</value>
 			<value>1</value>
 			<value>0</value>
+			<value>pages_default.html</value>
 		</row>
 		<row>
 			<value>4</value>
@@ -68,6 +72,7 @@
 			<value>1</value>
 			<value>0</value>
 			<value>0</value>
+			<value>pages_default.html</value>
 		</row>
 	</table>
 	<table name="phpbb_pages_links">

--- a/tests/operators/page_operator_get_page_templates.php
+++ b/tests/operators/page_operator_get_page_templates.php
@@ -1,0 +1,51 @@
+<?php
+/**
+*
+* Pages extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2014 phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace phpbb\pages\tests\operators;
+
+class page_operator_get_page_templates_test extends page_operator_base
+{
+	/**
+	* Test data for the test_get_templates() function
+	*
+	* @return array Array of test routes
+	* @access public
+	*/
+	public function get_templates_test_data()
+	{
+		return array(
+			array(
+				array(
+					'ext/phpbb/pages/styles/prosilver/template/pages_blank.html' => 'phpbb/pages',
+					'ext/phpbb/pages/styles/prosilver/template/pages_default.html' => 'phpbb/pages',
+					'ext/phpbb/pages/styles/subsilver2/template/pages_blank.html' => 'phpbb/pages',
+					'ext/phpbb/pages/styles/subsilver2/template/pages_default.html' => 'phpbb/pages',
+				),
+			),
+		);
+	}
+
+	/**
+	* Test getting page templates from the filesystem
+	*
+	* @dataProvider get_templates_test_data
+	* @access public
+	*/
+	public function test_get_templates($expected)
+	{
+		// Setup the operator class
+		$operator = $this->get_page_operator();
+
+		// Grab the route data as an array
+		$templates = $operator->get_page_templates();
+
+		$this->assertEquals($expected, $templates);
+	}
+}


### PR DESCRIPTION
FYI: I know that normally we would use new migrations, but I want to make an exception in this case and update our existing migration. I'd like to keep all our basic table changes together, and this makes the up-coming MOD conversion migrators a little easier to manage, and also because nobody should be using this ext yet - it simply is not in a usable state yet - so I'm not concerned yet about migration files being modified vs. adding new migrations at the moment.
