### PR TITLE
Add notes and a fix to the link location event files

### DIFF
--- a/styles/prosilver/template/event/overall_footer_teamlink_after.html
+++ b/styles/prosilver/template/event/overall_footer_teamlink_after.html
@@ -1,3 +1,4 @@
+{# Note: we must use the before code so the link will appear in the expected location #}
 <!-- IF S_OVERALL_FOOTER_TEAMLINK_BEFORE -->
 	<!-- BEGIN overall_footer_teamlink_before_links -->
 		<li class="small-icon icon-pages rightside"<!-- IF overall_footer_timezone_before_links.ICON_LINK --> style="background-image: url('{T_THEME_PATH}/images/{overall_footer_timezone_before_links.ICON_LINK}');"<!-- ENDIF -->>

--- a/styles/prosilver/template/event/overall_footer_teamlink_before.html
+++ b/styles/prosilver/template/event/overall_footer_teamlink_before.html
@@ -1,3 +1,4 @@
+{# Note: we must use the after code so the link will appear in the expected location #}
 <!-- IF S_OVERALL_FOOTER_TEAMLINK_AFTER -->
 	<!-- BEGIN overall_footer_teamlink_after_links -->
 		<li class="small-icon icon-pages rightside"<!-- IF overall_footer_timezone_after_links.ICON_LINK --> style="background-image: url('{T_THEME_PATH}/images/{overall_footer_timezone_after_links.ICON_LINK}');"<!-- ENDIF -->>

--- a/styles/prosilver/template/event/overall_footer_timezone_after.html
+++ b/styles/prosilver/template/event/overall_footer_timezone_after.html
@@ -1,3 +1,4 @@
+{# Note: we must use the before code so the link will appear in the expected location #}
 <!-- IF S_OVERALL_FOOTER_TIMEZONE_BEFORE -->
 	<!-- BEGIN overall_footer_timezone_before_links -->
 		<li class="small-icon icon-pages rightside"<!-- IF overall_footer_timezone_before_links.ICON_LINK --> style="background-image: url('{T_THEME_PATH}/images/{overall_footer_timezone_before_links.ICON_LINK}');"<!-- ENDIF -->>

--- a/styles/prosilver/template/event/overall_footer_timezone_before.html
+++ b/styles/prosilver/template/event/overall_footer_timezone_before.html
@@ -1,3 +1,4 @@
+{# Note: we must use the after code so the link will appear in the expected location #}
 <!-- IF S_OVERALL_FOOTER_TIMEZONE_AFTER -->
 	<!-- BEGIN overall_footer_timezone_after_links -->
 		<li class="small-icon icon-pages rightside"<!-- IF overall_footer_timezone_before_links.ICON_LINK --> style="background-image: url('{T_THEME_PATH}/images/{overall_footer_timezone_before_links.ICON_LINK}');"<!-- ENDIF -->>

--- a/styles/subsilver2/template/event/overall_footer_timezone_after.html
+++ b/styles/subsilver2/template/event/overall_footer_timezone_after.html
@@ -1,3 +1,4 @@
+{# Note: we must use the before code so the link will appear in the expected location #}
 <!-- IF S_OVERALL_FOOTER_TIMEZONE_BEFORE -->
 	<!-- BEGIN overall_footer_timezone_before_links -->
 		<p class="datetime">

--- a/styles/subsilver2/template/event/overall_footer_timezone_before.html
+++ b/styles/subsilver2/template/event/overall_footer_timezone_before.html
@@ -1,3 +1,4 @@
+{# Note: we must use the after code so the link will appear in the expected location #}
 <!-- IF S_OVERALL_FOOTER_TIMEZONE_AFTER -->
 	<!-- BEGIN overall_footer_timezone_after_links -->
 		<p class="datetime">

--- a/styles/subsilver2/template/event/overall_header_navigation_append.html
+++ b/styles/subsilver2/template/event/overall_header_navigation_append.html
@@ -1,3 +1,4 @@
+{# Note: we are using the prepend code so the link will appear in a fashion consistent with prosilver #}
 <!-- IF S_OVERALL_HEADER_NAVIGATION_PREPEND -->
 	<!-- BEGIN overall_header_navigation_prepend_links -->
 		&nbsp; &nbsp;<a href="{overall_header_navigation_prepend_links.U_LINK_URL}"><img src="<!-- IF overall_header_navigation_prepend_links.ICON_LINK -->{T_THEME_PATH}/images/{overall_header_navigation_prepend_links.ICON_LINK}<!-- ELSE -->{T_THEME_PATH}/images/icon_mini_message.gif<!-- ENDIF -->" width="12" height="13" alt="*" /> {overall_header_navigation_prepend_links.LINK_TITLE}</a>

--- a/styles/subsilver2/template/event/overall_header_navigation_prepend.html
+++ b/styles/subsilver2/template/event/overall_header_navigation_prepend.html
@@ -1,3 +1,4 @@
+{# Note: we are using the append code so the link will appear in a fashion consistent with prosilver #}
 <!-- IF S_OVERALL_HEADER_NAVIGATION_APPEND -->
 	<!-- BEGIN overall_header_navigation_append_links -->
 		<a href="{overall_header_navigation_append_links.U_LINK_URL}"><img src="<!-- IF overall_header_navigation_append_links.ICON_LINK -->{T_THEME_PATH}/images/{overall_header_navigation_append_links.ICON_LINK}<!-- ELSE -->{T_THEME_PATH}/images/icon_mini_message.gif<!-- ENDIF -->" width="12" height="13" alt="*" /> {overall_header_navigation_append_links.LINK_TITLE}</a>&nbsp; &nbsp;


### PR DESCRIPTION
Since event names refer to code placement, and not rendered placement on screen, some after/before usages needed to be swapped, so that links would actually appear in the expected location, for either subsilver or prosilver.
