### PR TITLE
Add compatibility with phpBB 3.2 text formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 	"extra": {
 		"display-name": "Pages",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.1.3,<3.2.*@dev"
+			"phpbb/phpbb": ">=3.1.3,<3.3.*@dev"
 		},
 		"version-check": {
 			"host": "www.phpbb.com",

--- a/config/services.yml
+++ b/config/services.yml
@@ -46,6 +46,7 @@ services:
             - @config
             - @dispatcher
             - %phpbb.pages.tables.pages%
+            - @?text_formatter.utils # optional to allow bc with phpBB 3.1
 
     phpbb.pages.operator:
         class: phpbb\pages\operators\page

--- a/entity/page.php
+++ b/entity/page.php
@@ -45,6 +45,9 @@ class page implements page_interface
 	/** @var \phpbb\event\dispatcher_interface */
 	protected $phpbb_dispatcher;
 
+	/** @var \phpbb\textformatter\s9e\utils */
+	protected $text_formatter_utils;
+
 	/**
 	* The database table the page data is stored in
 	*
@@ -55,18 +58,20 @@ class page implements page_interface
 	/**
 	* Constructor
 	*
-	* @param \phpbb\db\driver\driver_interface    $db                 Database object
-	* @param \phpbb\config\config                 $config             Config object
-	* @param \phpbb\event\dispatcher_interface    $phpbb_dispatcher   Event dispatcher
-	* @param string                               $pages_table        Name of the table used to store page data
+	* @param \phpbb\db\driver\driver_interface   $db                    Database object
+	* @param \phpbb\config\config                $config                Config object
+	* @param \phpbb\event\dispatcher_interface   $phpbb_dispatcher      Event dispatcher
+	* @param string                              $pages_table           Name of the table used to store page data
+	* @param \phpbb\textformatter\s9e\utils      $text_formatter_utils  Text manipulation utilities
 	* @access public
 	*/
-	public function __construct(\phpbb\db\driver\driver_interface $db, \phpbb\config\config $config, \phpbb\event\dispatcher_interface $phpbb_dispatcher, $pages_table)
+	public function __construct(\phpbb\db\driver\driver_interface $db, \phpbb\config\config $config, \phpbb\event\dispatcher_interface $phpbb_dispatcher, $pages_table, \phpbb\textformatter\s9e\utils $text_formatter_utils = null)
 	{
 		$this->db = $db;
 		$this->config = $config;
 		$this->dispatcher = $phpbb_dispatcher;
 		$this->pages_table = $pages_table;
+		$this->text_formatter_utils = $text_formatter_utils;
 	}
 
 	/**
@@ -511,6 +516,13 @@ class page implements page_interface
 		// Generate for display
 		if ($content_html_enabled)
 		{
+			// This is required by s9e text formatter to
+			// remove extra xml formatting from the content.
+			if ($this->text_formatter_utils !== null)
+			{
+				$content = $this->text_formatter_utils->unparse($content);
+			}
+
 			$content = htmlspecialchars_decode($content, ENT_COMPAT);
 		}
 		else


### PR DESCRIPTION
This change will be needed for compatibility with phpBB 3.2. It's implementing a new optional dependency so this makes Pages compatible with both 3.1.x and 3.2.x